### PR TITLE
Fix IL icon; properly add IN

### DIFF
--- a/src/lib/StateIcon.svelte
+++ b/src/lib/StateIcon.svelte
@@ -44,6 +44,8 @@
 		{:else if stateCode == 'ID'}
 			<svg data-inline-src="ID.svg" />
 		{:else if stateCode == 'IL'}
+			<svg data-inline-src="IL.svg" />
+		{:else if stateCode == 'IN'}
 			<svg data-inline-src="IN.svg" />
 		{:else if stateCode == 'KS'}
 			<svg data-inline-src="KS.svg" />


### PR DESCRIPTION
Was exploring the site after your recent post on LinkedIn and noticed this fluke in the icons list 🙂

Old:
<img width="869" height="201" alt="image" src="https://github.com/user-attachments/assets/6e527f85-8d8a-4b18-b436-f9c4ca2d9aed" />

New:
<img width="867" height="205" alt="image" src="https://github.com/user-attachments/assets/dc55a6a2-3d25-4d91-97cb-f5e09c8caacb" />

Hope you're well!